### PR TITLE
Strip invalid rings out of polygons on conversion

### DIFF
--- a/spec/arcgisSpec.js
+++ b/spec/arcgisSpec.js
@@ -108,6 +108,27 @@ describe("ArcGIS Tools", function(){
     });
   });
 
+  it("should strip invalid rings when converting a GeoJSON Polygon to and ArcGIS Polygon", function() {
+    var input = {
+      "type": "Polygon",
+      "coordinates": [
+        [ [100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0] ],
+        [ [100.2,0.2],[100.8,0.2],[100.2,0.2] ]
+      ]
+    };
+
+    var output = Terraformer.ArcGIS.convert(input);
+
+    expect(output).toEqual({
+      "rings": [
+        [ [100, 0], [100, 1], [101, 1], [101, 0], [100, 0] ]
+      ],
+      "spatialReference":{
+        "wkid":4326
+      }
+    });
+  });
+
   it("should close ring when converting a GeoJSON Polygon w/ a hole to an ArcGIS Polygon", function() {
     var input = {
       "type": "Polygon",
@@ -624,6 +645,25 @@ describe("ArcGIS Tools", function(){
       ]
     ]);
     expect(output.type).toEqual("MultiPolygon");
+  });
+
+  it("should strip invalid rings when converting ArcGIS Polygons to GeoJSON", function() {
+    var input = {
+      "rings":[
+        [[-122.63,45.52],[-122.57,45.53],[-122.52,45.50],[-122.49,45.48],[-122.64,45.49],[-122.63,45.52],[-122.63,45.52]],
+        [[-83,35],[-74,35],[-83,35]] // closed but too small
+      ],
+      "spatialReference": {
+        "wkid":4326
+      }
+    };
+
+    var output = Terraformer.ArcGIS.parse(input);
+
+    expect(output.coordinates).toEqual([
+      [ [-122.63,45.52],[-122.57,45.53],[-122.52,45.5],[-122.49,45.48],[-122.64,45.49],[-122.63,45.52],[-122.63,45.52] ]
+    ]);
+    expect(output.type).toEqual("Polygon");
   });
 
   it("should properly close rings when converting an ArcGIS Polygon in a Terraformer GeoJSON MultiPolygon", function() {

--- a/terraformer-arcgis-parser.js
+++ b/terraformer-arcgis-parser.js
@@ -101,19 +101,22 @@
     var output = [];
     var polygon = poly.slice(0);
     var outerRing = closeRing(polygon.shift().slice(0));
-
-    if(!ringIsClockwise(outerRing)){
-      outerRing.reverse();
-    }
-
-    output.push(outerRing);
-
-    for (var i = 0; i < polygon.length; i++) {
-      var hole = closeRing(polygon[i].slice(0));
-      if(ringIsClockwise(hole)){
-        hole.reverse();
+    if(outerRing.length >= 4){
+      if(!ringIsClockwise(outerRing)){
+        outerRing.reverse();
       }
-      output.push(hole);
+
+      output.push(outerRing);
+
+      for (var i = 0; i < polygon.length; i++) {
+        var hole = closeRing(polygon[i].slice(0));
+        if(hole.length >= 4){
+          if(ringIsClockwise(hole)){
+            hole.reverse();
+          }
+          output.push(hole);
+        }
+      }
     }
 
     return output;
@@ -171,7 +174,9 @@
     // for each ring
     for (var r = 0; r < rings.length; r++) {
       var ring = closeRing(rings[r].slice(0));
-
+      if(ring.length < 4){
+        continue;
+      }
       // is this ring an outer ring? is it clockwise?
       if(ringIsClockwise(ring)){
         var polygon = [ ring ];


### PR DESCRIPTION
After spending a pretty good chunk of yesterday trying to get the [NYC Police Precincts](https://data.cityofnewyork.us/Public-Safety/Police-Precincts/78dh-3ptz) imported to a feature service I narrowed the issue down to some of the polygons containing invalid rings.

[GeoJSON](http://geojson.org/geojson-spec.html#linestring) defines a "ring" as

> A LinearRing is closed LineString with 4 or more positions. The first and last positions are equivalent (they represent equivalent points)

While the [ArcGIS JSON format](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Geometry_Objects/02r3000000n1000000/) is relatively undefined about the minimum number of points or the requirement to be closed, ArcGIS feature services reject polygons with fewer then 4 points or unclosed polygons.

It would probably be best not to covert rings with 3 or less points and just ignore them.
