### PR TITLE
Don't add an id if no id in original

### DIFF
--- a/terraformer-arcgis-parser.js
+++ b/terraformer-arcgis-parser.js
@@ -346,7 +346,9 @@
         result.geometry = convert(geojson.geometry, options);
       }
       result.attributes = (geojson.properties) ? clone(geojson.properties) : {};
-      result.attributes[idAttribute] = geojson.id;
+      if(geojson.id) {
+        result.attributes[idAttribute] = geojson.id;
+      }
       break;
     case "FeatureCollection":
       result = [];


### PR DESCRIPTION
Cannot add a feature on AGS if `OBJECTID` is `undefined`.