### PR TITLE
Fix issues with outer rings not containing holes

### DIFF
--- a/spec/arcgisSpec.js
+++ b/spec/arcgisSpec.js
@@ -304,6 +304,24 @@ describe("ArcGIS Tools", function(){
     });
   });
 
+  it('should still parse holes outside the outer rings', function(){
+    var input = {
+      "rings": [
+        [ [-122.45,45.63], [-122.45,45.68], [-122.39,45.68], [-122.39,45.63], [-122.45,45.63] ],
+        [ [-122.46,45.64], [-122.4,45.64], [-122.4,45.66], [-122.46,45.66], [-122.46,45.64] ]
+      ]
+    }
+
+    var output = Terraformer.ArcGIS.parse(input);
+
+    var expected = [
+      [ [-122.45,45.63], [-122.45,45.68], [-122.39,45.68], [-122.39,45.63], [-122.45,45.63] ],
+      [ [-122.46,45.64], [-122.4,45.64], [-122.4,45.66], [-122.46,45.66], [-122.46,45.64] ]
+    ];
+
+    expect(output.coordinates).toEqual(expected);
+  });
+
   it("should convert a GeoJSON Feature into an ArcGIS Feature", function(){
     var input = {
       "type":"Feature",

--- a/terraformer-arcgis-parser.js
+++ b/terraformer-arcgis-parser.js
@@ -170,6 +170,9 @@
   function convertRingsToGeoJSON(rings){
     var outerRings = [];
     var holes = [];
+    var x; // iterator
+    var outerRing; // current outer ring being evaluated
+    var hole; // current hole being evaluated
 
     // for each ring
     for (var r = 0; r < rings.length; r++) {
@@ -186,41 +189,64 @@
       }
     }
 
+    var uncontainedHoles = [];
+
     // while there are holes left...
     while(holes.length){
       // pop a hole off out stack
-      var hole = holes.pop();
-      var matched = false;
+      hole = holes.pop();
 
       // loop over all outer rings and see if they contain our hole.
-      for (var x = outerRings.length - 1; x >= 0; x--) {
-        var outerRing = outerRings[x][0];
+      var contained = false;
+      for (x = outerRings.length - 1; x >= 0; x--) {
+        outerRing = outerRings[x][0];
         if(coordinatesContainCoordinates(outerRing, hole)){
           // the hole is contained push it into our polygon
           outerRings[x].push(hole);
-
-          // we matched the hole
-          matched = true;
-
-          // stop checking to see if other outer rings contian this hole
+          contained = true;
           break;
         }
       }
 
-      // no outer rings contain this hole turn it into and outer ring (reverse it)
-      if(!matched){
-        outerRings.push([ hole.reverse() ]);
+      // ring is not contained in any outer ring
+      // sometimes this happens https://github.com/Esri/esri-leaflet/issues/320
+      if(!contained){
+        uncontainedHoles.push(hole);
+      }
+    }
+
+    // if we couldn't match any holes using contains we can now try intersects...
+    while(uncontainedHoles.length){
+      // pop a hole off out stack
+      hole = uncontainedHoles.pop();
+
+      // loop over all outer rings and see if any intersect our hole.
+      var intersects = false;
+      for (x = outerRings.length - 1; x >= 0; x--) {
+        outerRing = outerRings[x][0];
+        if(Terraformer.Tools.arraysIntersectArrays(outerRing, hole)){
+          // the hole intersects the outer ring push it into our polygon
+          outerRings[x].push(hole);
+          intersects = true;
+          break;
+        }
+      }
+
+      // hole does not intersect ANY outer ring at this point
+      // make it an outer ring.
+      if(!intersects) {
+        outerRings.push([hole.reverse()]);
       }
     }
 
     if(outerRings.length === 1){
       return {
-        type: "Polygon",
+        type: 'Polygon',
         coordinates: outerRings[0]
       };
     } else {
       return {
-        type: "MultiPolygon",
+        type: 'MultiPolygon',
         coordinates: outerRings
       };
     }


### PR DESCRIPTION
This is a result of trying to fix https://github.com/Esri/esri-leaflet/issues/320. Under certain conditions it is possible for outer rings to not always contain holes.

The solution is to check again to see if the hole intersects an outer ring after checking contains against every outer ring.

If a ring neither intersects another ring or is contained inside it it will be turned into an outer ring.