### PR TITLE
stop reprojecting mercator coordinates

### DIFF
--- a/spec/arcgisSpec.js
+++ b/spec/arcgisSpec.js
@@ -964,23 +964,17 @@ describe("ArcGIS Tools", function(){
     expect(output.properties.foo).toEqual("bar");
   });
 
-  it("should convert to WGS84/4326 while parsing", function(){
+  it("should not reproject to WGS84/4326 while parsing", function(){
     var input = {
       "x": -13580977.876779145,
       "y": 5621521.486191948,
       "spatialReference": {
-        "wkid": 102100
+        "wkid": 3857
       }
     };
 
-    var expectedOutput = {
-      "type": "Point",
-      "coordinates": [-122, 45]
-    };
-
     var output = Terraformer.ArcGIS.parse(input);
-
-    expect(output.coordinates).toEqual([-121.99999999999794, 44.99999999999924]);
+    expect(output.coordinates).toEqual([-13580977.876779145, 5621521.486191948]);
   });
 
   it("should not modify the original ArcGIS Geometry", function(){

--- a/terraformer-arcgis-parser.js
+++ b/terraformer-arcgis-parser.js
@@ -307,13 +307,6 @@
       }
     }
 
-    var inputSpatialReference = (arcgis.geometry) ? arcgis.geometry.spatialReference : arcgis.spatialReference;
-
-    //convert spatial ref if needed
-    if(inputSpatialReference && inputSpatialReference.wkid === 102100){
-      geojson = Terraformer.toGeographic(geojson);
-    }
-
     return new Terraformer.Primitive(geojson);
   }
 

--- a/terraformer-arcgis-parser.js
+++ b/terraformer-arcgis-parser.js
@@ -259,6 +259,10 @@
     options = options || {};
     options.idAttribute = options.idAttribute || undefined;
 
+    if (arcgis.spatialReference && (arcgis.spatialReference.wkid === 3857 || arcgis.spatialReference.wkid === 102100)) {
+      geojson.crs = Terraformer.MercatorCRS;
+    }
+
     if(typeof arcgis.x === 'number' && typeof arcgis.y === 'number'){
       geojson.type = "Point";
       geojson.coordinates = [arcgis.x, arcgis.y];


### PR DESCRIPTION
resolves #30 

we currently document the fact that we reproject web mercator coordinates. does that make this a breaking change that bumps the major version number?

http://terraformer.io/arcgis-parser/#arcgisconvert

> Notes: If the object is in the Web Mercator spatial reference it will be converted to WGS84.