### PR TITLE
for custom crs, dont set spatialReference of output

### DIFF
--- a/spec/arcgisSpec.js
+++ b/spec/arcgisSpec.js
@@ -569,7 +569,7 @@ describe("ArcGIS Tools", function(){
     expect(original).toEqual(JSON.stringify(primitive));
   });
 
-  it("if the GeoJSON includes a custom crs, output spatial reference shouldnt be set", function() {
+  it("if the GeoJSON includes a custom crs, output spatial reference should not be set", function() {
     var input = {
       "type": "Point",
       "coordinates": [123,456],
@@ -583,6 +583,28 @@ describe("ArcGIS Tools", function(){
 
     var output = Terraformer.ArcGIS.convert(input);
 
+    expect(output).toEqual({
+      "x": 123,
+      "y": 456,
+      "spatialReference": null
+    });
+  });
+
+  it("if the GeoJSON includes a custom linked crs, output spatial reference should not be set", function() {
+    var input = {
+      "type": "Point",
+      "coordinates": [123,456],
+      "crs": {
+        "type": "link",
+        "properties": {
+          "href": "http://spatialreference.org/ref/sr-org/7/ogcwkt/",
+          "type": "ogcwkt"
+        }
+      },
+    };
+
+    var output = Terraformer.ArcGIS.convert(input);
+    console.log(output);
     expect(output).toEqual({
       "x": 123,
       "y": 456,

--- a/spec/arcgisSpec.js
+++ b/spec/arcgisSpec.js
@@ -30,6 +30,7 @@ describe("ArcGIS Tools", function(){
       }
     });
   });
+
   it("should convert a GeoJSON Point with Z to an ArcGIS Point with Z", function() {
     var input = {
       "type": "Point",
@@ -566,6 +567,27 @@ describe("ArcGIS Tools", function(){
     Terraformer.ArcGIS.convert(primitive);
 
     expect(original).toEqual(JSON.stringify(primitive));
+  });
+
+  it("if the GeoJSON includes a custom crs, output spatial reference shouldnt be set", function() {
+    var input = {
+      "type": "Point",
+      "coordinates": [123,456],
+      "crs": {
+        "type": "name",
+        "properties": {
+          "name": "urn:ogc:def:crs:EPSG::2913"
+        }
+      }
+    };
+
+    var output = Terraformer.ArcGIS.convert(input);
+
+    expect(output).toEqual({
+      "x": 123,
+      "y": 456,
+      "spatialReference": null
+    });
   });
 
   it("should parse an ArcGIS Point in a Terraformer GeoJSON Point", function() {

--- a/terraformer-arcgis-parser.js
+++ b/terraformer-arcgis-parser.js
@@ -326,8 +326,8 @@
 
     if(options.sr){
       spatialReference = { wkid: options.sr };
-    } else if (geojson && geojson.crs === Terraformer.MercatorCRS) {
-      spatialReference = { wkid: 102100 };
+    } else if (geojson && geojson.crs && geojson.crs.properties.name != "urn:ogc:def:crs:OGC:1.3:CRS84") {
+      spatialReference = null;
     } else {
       spatialReference = { wkid: 4326 };
     }


### PR DESCRIPTION
resolves #26 

* because its tricky to interpret any number of CRS styles and convert them into an ArcGIS spatial reference JSON object
* and because `sr` is already available to pass as an input option to `convert()`
* and because GeoJSON w/ crs isn't a popular thing...

 lets just be a little less clever.