### PR TITLE
Fix bug that would cause ArcGIS extents to fail to parse when a value is 0

### DIFF
--- a/terraformer-arcgis-parser.js
+++ b/terraformer-arcgis-parser.js
@@ -293,7 +293,12 @@
       geojson = convertRingsToGeoJSON(arcgis.rings.slice(0));
     }
 
-    if(arcgis.xmin && arcgis.ymin && arcgis.xmax && arcgis.ymax) {
+    if(
+      typeof arcgis.xmin === "number" &&
+      typeof arcgis.ymin === "number" &&
+      typeof arcgis.xmax === "number" &&
+      typeof arcgis.ymax === "number"
+    ) {
       geojson.type = "Polygon";
       geojson.coordinates = [[
         [arcgis.xmax, arcgis.ymax],


### PR DESCRIPTION
Sorry, I accidently left a bug in my previous PR, this should fix that. It's already fixed in Esri/arcgis-to-geojson-utils#34.

On an unrelated note, is there a reason this library doesn't use Esri/arcgis-to-geojson-utils as a dependency and use the functions in there? Just that there seems to  be a lot of code duplication between the two. This might have been intentional, but I am just interested!

Thanks